### PR TITLE
Refactored to utilize Observer-Subject Pattern

### DIFF
--- a/src/swen225/murdermadness/GrabAsset.java
+++ b/src/swen225/murdermadness/GrabAsset.java
@@ -1,0 +1,15 @@
+package swen225.murdermadness;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+public final class GrabAsset {
+    public static BufferedImage grabAsset(String path) {
+        try {
+            BufferedImage img = ImageIO.read(new File(path));
+            return img;
+        } catch (Exception e) {e.printStackTrace();}
+        return null;
+    }
+}

--- a/src/swen225/murdermadness/Observer.java
+++ b/src/swen225/murdermadness/Observer.java
@@ -5,9 +5,18 @@ import java.util.Map;
 
 public interface Observer {
 
-    void onNotify(Subject.Event event);
+    /**
+     * Update in response to an event,
+     */
+    void update(Subject.Event event);
 
-    void onNotify(Object obj, Subject.Event event);
+    /**
+     * Update in response to an event, using passed Object passed as required
+     */
+    void update(Object obj, Subject.Event event);
 
-    void onNotify(Map<String, String> collection, BufferedImage img, Subject.Event event);
+    /**
+     * Retrieve object an as required
+     */
+    Object retrieve(Subject.Event obj);
 }

--- a/src/swen225/murdermadness/Subject.java
+++ b/src/swen225/murdermadness/Subject.java
@@ -4,11 +4,25 @@ import java.awt.image.BufferedImage;
 import java.util.Map;
 
 public interface Subject {
-    enum Event { LEFT,RIGHT,UP,DOWN,SETUP,UPDATE_BOARD,SET_STEPS,SHOW_HAND,RESET }
+    /**
+     * List of possible events that an observer can respond to
+     */
+    enum Event { LEFT,RIGHT,UP,DOWN,SETUP,UPDATE_BOARD,SET_STEPS,RESET,
+        UPDATE_ELIM,GATHER_CARDS,CHOOSE,GUESS,ACCUSE,SET_CHOSEN,CURRENT_PLAYER}
 
+    /**
+     * Notify the observers of an event
+     */
     void notify(Event event);
 
+    /**
+     * Notify the Observer of an event, pass an Object that is required to
+     * complete action
+     */
     void notify(Object obj, Event event);
 
-    void notify(Map<String, String> collection, BufferedImage img, Subject.Event event);
+    /**
+     * Request for an object from an Observer
+     */
+    Object request(Event object);
 }

--- a/src/swen225/murdermadness/gui/ActionPanel.java
+++ b/src/swen225/murdermadness/gui/ActionPanel.java
@@ -5,25 +5,28 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.util.List;
 
 import javax.swing.*;
 
 import swen225.murdermadness.MurderMadness;
 import swen225.murdermadness.MurderMadness.Direction;
+import swen225.murdermadness.Observer;
+import swen225.murdermadness.Subject;
 
 /**
  * Panel contains buttons for actions for a player. Also contains the hotkey bindings for the same actions
  */
-public class ActionPanel extends JPanel {
+public class ActionPanel extends JPanel implements Subject {
 
-	private MurderMadness model;
+	private final List<Observer> observers;
 	private GUI view;
 	
 	private JButton roll, hand;
 	private JButton west, east, north, south;
 	
-	public ActionPanel(MurderMadness model, GUI view) {
-		this.model = model;
+	public ActionPanel(List<Observer> observers, GUI view) {
+		this.observers = observers;
 		this.view = view;
 		initialise();
 	}
@@ -48,8 +51,8 @@ public class ActionPanel extends JPanel {
 		west.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
-				model.onPlayerMove(Direction.LEFT);
-				model.updateBoard(view.getGraphics());
+				ActionPanel.this.notify(Event.LEFT);
+				ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 			}
 		});west.setEnabled(false);
 
@@ -57,8 +60,8 @@ public class ActionPanel extends JPanel {
 		east.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
-				model.onPlayerMove(Direction.RIGHT);
-				model.updateBoard(view.getGraphics());
+				ActionPanel.this.notify(Event.RIGHT);
+				ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 			}
 		});east.setEnabled(false);
 
@@ -66,8 +69,8 @@ public class ActionPanel extends JPanel {
 		north.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
-				model.onPlayerMove(Direction.UP);
-				model.updateBoard(view.getGraphics());
+				ActionPanel.this.notify(Event.UP);
+				ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 			}
 		});north.setEnabled(false);
 
@@ -75,8 +78,8 @@ public class ActionPanel extends JPanel {
 		south.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
-				model.onPlayerMove(Direction.DOWN);
-				model.updateBoard(view.getGraphics());
+				ActionPanel.this.notify(Event.DOWN);
+				ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 			}
 		});south.setEnabled(false);
 
@@ -153,26 +156,27 @@ public class ActionPanel extends JPanel {
 				switch (ev.getActionCommand()) {
 					case ("LEFT"):
 						if (west.isEnabled()) {
-							model.onPlayerMove(Direction.LEFT);
-							model.updateBoard(view.getGraphics());
+							ActionPanel.this.notify(Event.LEFT);
+							ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 						}
 						break;
 					case ("RIGHT"):
 						if (east.isEnabled()) {
-							model.onPlayerMove(Direction.RIGHT);
-							model.updateBoard(view.getGraphics());
+							ActionPanel.this.notify(Event.RIGHT);
+							ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 						}
 						break;
 					case ("UP"):
 						if (north.isEnabled()) {
-							model.onPlayerMove(Direction.UP);
-							model.updateBoard(view.getGraphics());
+							ActionPanel.this.notify(Event.UP);
+							ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 						}
+
 						break;
 					case ("DOWN"):
 						if (south.isEnabled()) {
-							model.onPlayerMove(Direction.DOWN);
-							model.updateBoard(view.getGraphics());
+							ActionPanel.this.notify(Event.DOWN);
+							ActionPanel.this.notify(view.getGraphics(), Event.UPDATE_BOARD);
 						}
 						break;
 					case ("HAND"):
@@ -181,6 +185,26 @@ public class ActionPanel extends JPanel {
 				}
 			}
 		}
+	}
+
+	@Override
+	public void notify(Event event) {
+		for(Observer o : observers){
+			o.update(event);
+		}
+	}
+
+	@Override
+	public void notify(Object obj, Event event) {
+		for(Observer o : observers){
+			o.update(obj, event);
+		}
+	}
+
+	@Override
+	public Object request(Event object) {
+		//not used
+		return null;
 	}
 
 }

--- a/src/swen225/murdermadness/gui/GUI.java
+++ b/src/swen225/murdermadness/gui/GUI.java
@@ -9,13 +9,13 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.*;
 import javax.swing.border.Border;
 import javax.swing.text.DefaultCaret;
 
-import swen225.murdermadness.MurderMadness;
-import swen225.murdermadness.Player;
+import swen225.murdermadness.*;
 import swen225.murdermadness.cards.Card;
 
 /**
@@ -24,9 +24,10 @@ import swen225.murdermadness.cards.Card;
  * a panel to display eliminations and a panel to display the user HUD. Finally a menu is added to the frame, which allows
  * the player to quit or start a new game.
  */
-public class GUI {
+public class GUI implements Subject {
 
-	private MurderMadness model;
+	private final List<Observer> observers;
+
 	private GameSetupFrame setupFrame;
 	private JFrame guessAccuse;
 
@@ -46,9 +47,9 @@ public class GUI {
 
 	private static Color BACKGROUND_COLOR = new Color(120, 116, 119);
 
-	public GUI(MurderMadness model) {
-		this.model = model;
-		setupFrame = new GameSetupFrame(model);
+	public GUI(List<Observer> observers) {
+		this.observers = observers;
+		setupFrame = new GameSetupFrame(observers);
 	}
 
 	/**
@@ -64,7 +65,7 @@ public class GUI {
 		guessAccuse.setLocationRelativeTo(null);
     	
     	// Action Buttons
-    	actionControl = new ActionPanel(model, this);
+    	actionControl = new ActionPanel(observers, this);
 
 		playerTurnLabel = new JLabel();
 		playerTurnLabel.setText("A Game of MurderMadness has Started!");
@@ -98,8 +99,7 @@ public class GUI {
     	drawing = new JPanel() {
     		@Override
     		public void paintComponent(Graphics g) {
-    			Graphics2D g2d = (Graphics2D) g;
-    			model.updateBoard(g2d);
+				GUI.this.notify((Graphics2D) g, Event.UPDATE_BOARD);
     		}
     	};
     	drawing.setPreferredSize(new Dimension(DFLT_DRAWING_WIDTH,DFLT_DRAWING_HEIGHT));
@@ -108,7 +108,7 @@ public class GUI {
     	userHUD = new JPanel() {
     		@Override
     		public void paintComponent(Graphics g) {
-    			Graphics2D g2d = (Graphics2D) g;
+
     		}
     	};
 
@@ -121,8 +121,7 @@ public class GUI {
     	JPanel rightPanel = new JPanel() {
     		@Override
     		public void paintComponent(Graphics g) {
-    			Graphics2D g2d = (Graphics2D) g;
-    			model.updateElimination(g2d);
+				GUI.this.notify(g, Event.UPDATE_ELIM);
     		}
     	};
     	rightPanel.setBackground(BACKGROUND_COLOR);
@@ -157,7 +156,7 @@ public class GUI {
    				int selection = JOptionPane.showOptionDialog(null, panel, "WARNING!", JOptionPane.DEFAULT_OPTION,
     					JOptionPane.WARNING_MESSAGE, null, options, options[1]);
    				if (selection == 0) {
-   					setupFrame = new GameSetupFrame(model);
+   					setupFrame = new GameSetupFrame(observers);
    					frame.dispose();
    				}
    			}
@@ -171,7 +170,7 @@ public class GUI {
 			int selection = JOptionPane.showOptionDialog(null, panel, "WARNING!", JOptionPane.DEFAULT_OPTION,
 					JOptionPane.WARNING_MESSAGE, null, options, options[1]);
 			if (selection == 0) {
-				model.reset();
+				notify(Event.RESET);
 			}
 		});
 
@@ -207,7 +206,7 @@ public class GUI {
 			"assets/dice_5.png",
 			"assets/dice_6.png"));
 
-	
+
 	/*
 	 * Rolls the dice
 	 */
@@ -223,7 +222,7 @@ public class GUI {
 		int x = 0;
 		for(int i = 0; i<200;i++) {
 			x = i%6;
-			img3 = model.grabAsset(dicePicPath.get(x));
+			img3 = GrabAsset.grabAsset(dicePicPath.get(x));
 			g.clearRect(0, 0, userHUD.getWidth(), userHUD.getHeight());
 			g.drawImage(img3, 0, 0, 100, 100, null);
 			g.drawImage(img3, 100, 0, 100, 100, null);
@@ -231,44 +230,44 @@ public class GUI {
 		}
 		switch(roll1) {
 			case 1:
-				img1 = model.grabAsset("assets/dice_1.png");
+				img1 = GrabAsset.grabAsset("assets/dice_1.png");
 				break;
 			case 2:
-				img1 = model.grabAsset("assets/dice_2.png");
+				img1 = GrabAsset.grabAsset("assets/dice_2.png");
 				break;
 			case 3:
-				img1 = model.grabAsset("assets/dice_3.png");
+				img1 = GrabAsset.grabAsset("assets/dice_3.png");
 				break;
 			case 4:
-				img1 = model.grabAsset("assets/dice_4.png");
+				img1 = GrabAsset.grabAsset("assets/dice_4.png");
 				break;
 			case 5:
-				img1 = model.grabAsset("assets/dice_5.png");
+				img1 = GrabAsset.grabAsset("assets/dice_5.png");
 				break;
 			case 6:
-				img1 = model.grabAsset("assets/dice_6.png");
+				img1 = GrabAsset.grabAsset("assets/dice_6.png");
 				break;
 			default:
 				// code block
 		}
 		switch(roll2) {
 			case 1:
-				img2 = model.grabAsset("assets/dice_1.png");
+				img2 = GrabAsset.grabAsset("assets/dice_1.png");
 				break;
 			case 2:
-				img2 = model.grabAsset("assets/dice_2.png");
+				img2 = GrabAsset.grabAsset("assets/dice_2.png");
 				break;
 			case 3:
-				img2 = model.grabAsset("assets/dice_3.png");
+				img2 = GrabAsset.grabAsset("assets/dice_3.png");
 				break;
 			case 4:
-				img2 = model.grabAsset("assets/dice_4.png");
+				img2 = GrabAsset.grabAsset("assets/dice_4.png");
 				break;
 			case 5:
-				img2 = model.grabAsset("assets/dice_5.png");
+				img2 = GrabAsset.grabAsset("assets/dice_5.png");
 				break;
 			case 6:
-				img2 = model.grabAsset("assets/dice_6.png");
+				img2 = GrabAsset.grabAsset("assets/dice_6.png");
 				break;
 			default:
 		}
@@ -281,7 +280,9 @@ public class GUI {
 		Font font = new Font("Helvetica", Font.BOLD, 15);
 		g.setFont(font);
 		g.drawString("Rolled "+((int)roll1+(int)roll2), 220, 50);
-		model.setPlayerSteps(roll1+roll2);
+
+		notify(roll1+roll2, Event.SET_STEPS);
+
 		actionControl.setMove(true);
 		actionControl.setRoll(false);
 	}
@@ -329,14 +330,16 @@ public class GUI {
     	if (selection == 0) {
     		setStatus("You are currently Refuting");
     		setMode("Guess");
-    		model.gatherPossibleCards();
-    		model.triggerChoose();
+			notify(Event.GATHER_CARDS);
+			notify(Event.CHOOSE);
+
     		return false;
     	} else if (selection == 1) {
     		setStatus("You are currently Accusing");
     		setMode("Accuse");
-    		model.gatherPossibleCards();
-    		model.triggerChoose();
+			notify(Event.GATHER_CARDS);
+			notify(Event.CHOOSE);
+
     		return false;
     	}
     	return true;
@@ -345,9 +348,9 @@ public class GUI {
 
     public void checkLogic() {
     	if (guessAccuse.getTitle().equals("Guess")) {
-    		model.onGuess();
+			notify(Event.GUESS);
     	} else if (guessAccuse.getTitle().equals("Accuse")) {
-    		model.onAccuse();
+			notify(Event.ACCUSE);
     	}
     }
 
@@ -374,9 +377,9 @@ public class GUI {
 			    	int selection = JOptionPane.showOptionDialog(null, panel, "Confirm Decision", JOptionPane.DEFAULT_OPTION, 
 			    	JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
 			    	if (selection == 0) {
-			    		model.setChosenCard(c);
+						GUI.this.notify(c, Event.SET_CHOSEN);
 						guessAccuse.setVisible(false);
-			    		model.triggerChoose();
+						GUI.this.notify(Event.CHOOSE);
 			    	} else return;
 				}
 			});
@@ -399,10 +402,10 @@ public class GUI {
     public void showHand() {
     	Graphics2D g = (Graphics2D)this.userHUD.getGraphics();
     	g.clearRect(0, 0, userHUD.getWidth(), userHUD.getHeight()); // Clears the panel before drawing
-    	Player p = model.getCurrentPlayer();
+		Player p = (Player)request(Event.CURRENT_PLAYER);
     	List<Card> hand = p.getHand();
     	int padding = 50;
-    	
+
     	// Start drawing
     	for (Card c : hand) {
     		g.drawImage(c.getCardImage(), padding, 0, 100, 100, null);
@@ -422,5 +425,26 @@ public class GUI {
     	actionControl.setRoll(false);
     	actionControl.setMove(false);
     }
-    
+
+	@Override
+	public void notify(Event event) {
+		for(Observer o : observers){
+			o.update(event);
+		}
+	}
+
+	@Override
+	public void notify(Object obj, Event event) {
+		for(Observer o : observers){
+			o.update(obj,event);
+		}
+	}
+
+	public Object request(Event object){
+    	for(Observer o : observers){
+    		Object retrieved = o.retrieve(object);
+    		if(retrieved != null){ return retrieved; }
+		}
+    	return null;
+	}
 }

--- a/src/swen225/murdermadness/gui/GameSetupFrame.java
+++ b/src/swen225/murdermadness/gui/GameSetupFrame.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.swing.ButtonGroup;
@@ -17,16 +18,18 @@ import javax.swing.JLabel;
 import javax.swing.JRadioButton;
 
 import swen225.murdermadness.MurderMadness;
+import swen225.murdermadness.Observer;
+import swen225.murdermadness.Subject;
 
-public class GameSetupFrame extends JFrame implements ActionListener {
+public class GameSetupFrame extends JFrame implements ActionListener, Subject {
 	
-	private MurderMadness model;
+	List<Observer> observers;
 	
 	private int players = 0;
 	private Map<String, String> allPlayers;
 	
-	public GameSetupFrame(MurderMadness model) {
-		this.model = model;
+	public GameSetupFrame(List<Observer> observers) {
+		this.observers = observers;
 		initNumPlayers();
 	}
 	
@@ -165,7 +168,7 @@ public class GameSetupFrame extends JFrame implements ActionListener {
 		this.setTitle("Character Selection: Player "+count);
 		if (count == players) {
 			this.setVisible(false);
-			model.setup(allPlayers);
+			notify(allPlayers, Event.SETUP);
 			this.dispose();
 			nameInput.dispose();
 			return;
@@ -177,5 +180,25 @@ public class GameSetupFrame extends JFrame implements ActionListener {
 	
 	public Map<String, String> getPlayers(){
 		return this.allPlayers;
+	}
+
+	@Override
+	public void notify(Event event) {
+		for(Observer o : observers){
+			o.update(event);
+		}
+	}
+
+	@Override
+	public void notify(Object obj, Event event) {
+		for(Observer o : observers){
+			o.update(obj, event);
+		}
+	}
+
+	@Override
+	public Object request(Event object) {
+		//not used
+		return null;
 	}
 }


### PR DESCRIPTION
Feel free to paraphrase this in your report if we end up using this version:
Two interfaces have been created:
- Subject which contains notify(event), which passes an event enum.
- Observer, which contains update(event), which performs an action in response to the event.

GUI, ActionPanel, and GameSetupFrame all implement Subject and essentially act as controllers. 
MurderMadness implements Observer.
Each Subject class contains a 'list' of Observers (only one in this case because they only need to communicate with one other class).
When a Subject needs to send an instruction to an Observer, it uses notify(event) which iterates through all the observers in the list and tells them to update(event).
The Event enum determines what the Observer will do, so the Observers that respond to the particular enum will perform that action.

The main purpose of this pattern is to achieve decoupling, such that changes in one Subject do not necessarily affect the Observers, and vice versa.